### PR TITLE
Fix description of AD field

### DIFF
--- a/GBS-SNP-CROP-scripts/v.4.0/GBS-SNP-CROP-8.pl
+++ b/GBS-SNP-CROP-scripts/v.4.0/GBS-SNP-CROP-8.pl
@@ -279,7 +279,7 @@ if ($tools =~ "V" or $tools =~ "v") {
 	."##INFO=<ID=AV,Number=1,Type=Integer,Description=\"Average Depth\">\n"
 	."##INFO=<ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\">\n"
 	."##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n"
-	."##FORMAT=<ID=AD,Number=1,Type=Integer,Description=\"Allele Depth\">\n"
+	."##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allele Depth\">\n"
 	."#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t$Names\n";
 	
 	while (<$IN4>) {


### PR DESCRIPTION
In a VCF file, AD should have "R" values (i.e. one for each allele), rather than 1 value.  This was causing issues with import in Bioconductor.